### PR TITLE
Updated quick links in the topic task estimation

### DIFF
--- a/TaskEstimation/BestPractices.md
+++ b/TaskEstimation/BestPractices.md
@@ -1,0 +1,26 @@
+# Best Practices
+
+* **Engage the whole team**  
+  By giving everyone a chance to be involved in the estimation process you gain the benefits of having <ins>different insights</ins> and <ins>different perspectives</ins> on estimating a task. Essentially it generates a better consensus and commitment for the estimates being produced.
+
+* **Use multiple techniques**  
+  It is important to use multiple techniques or methods for estimating a task (e.g. planning poker, bottom-up, user story points, etc.) and look for similarities between multiple approaches to make sure the estimates are more accurate.
+
+* **Agree on the definition of "Done"**  
+  Make sure everyone agrees on a definition of done. It can mean:  
+  * Coded and tested
+  * Integrated and tested
+  * Integrated, tested and closed the JIRA task
+  * etc.
+
+* **Know when to stop**  
+  Estimating is not an exact science and it can be exhausting estimating an unpredictable task that can change because of evolving requirements. Make sure to get a <ins>broad consensus</ins> between team members. It is better to save time on estimation for potential periodic updates than wasting too much time now.
+
+* **Estimation is a continuous process**  
+  The initial estimate is not the final estimate. To avoid high levels of uncertainty, <ins>periodically review</ins> any uncertain estimates based on new information or requirements received.
+
+* **Aim to understand each other**  
+  Accept estimate values as long as there is a good rationale agreement. If there is any conflict, it must be handled within the team by understanding the reason for disagreement and adjust estimate values accordingly.
+
+* **Use non-linear scale**  
+  It is better to use a non-linear scale such as in the Fibonacci sequence, (e.g. 1,4,9,16). That is because it is quite hard to judge the difference in a linear scale between 3 and 4 compared to judging the difference between  4 and 9. To avoid number bias, clothes sizes can also be used (e.g. S,M,L,XL).

--- a/TaskEstimation/BestPractices.md
+++ b/TaskEstimation/BestPractices.md
@@ -24,3 +24,7 @@
 
 * **Use non-linear scale**  
   It is better to use a non-linear scale such as in the Fibonacci sequence, (e.g. 1,4,9,16). That is because it is quite hard to judge the difference in a linear scale between 3 and 4 compared to judging the difference between  4 and 9. To avoid number bias, clothes sizes can also be used (e.g. S,M,L,XL).
+
+More information can be found in the following websites:
+* [Agile Estimation Best Practices](https://thedigitalbusinessanalyst.co.uk/best-practices-for-agile-estimation-a3d4435a776a)
+* [Top 10 Agile Estimation Best Practices](https://leadinganswers.typepad.com/leading_answers/files/top_10_agile_estimation_guidelines.pdf)

--- a/TaskEstimation/BestPractices.md
+++ b/TaskEstimation/BestPractices.md
@@ -28,3 +28,7 @@
 More information can be found in the following websites:
 * [Agile Estimation Best Practices](https://thedigitalbusinessanalyst.co.uk/best-practices-for-agile-estimation-a3d4435a776a)
 * [Top 10 Agile Estimation Best Practices](https://leadinganswers.typepad.com/leading_answers/files/top_10_agile_estimation_guidelines.pdf)
+
+## Quick Links
+  * [Home Page](../README.md)
+  * [Task Estimation Home Page](TaskEstimation.md)

--- a/TaskEstimation/EstimationTechniques.md
+++ b/TaskEstimation/EstimationTechniques.md
@@ -17,5 +17,5 @@ Rather than using numbers like in planning poker, items can be classified using 
 There are also other techniques, like Affinity Estimation or Sorting Method. More info can be found [here](https://medium.com/@warren2lynch/top-7-most-popular-agile-estimation-methods-for-user-stories-69fccf5e418e).
 
 ## Quick Links
-  * [Home Page](../ProjectPlan.md)
-  * [Task Estimation](TaskEstimation.md)
+  * [Home Page](../README.md)
+  * [Task Estimation Home Page](TaskEstimation.md)

--- a/TaskEstimation/TaskEstimation.md
+++ b/TaskEstimation/TaskEstimation.md
@@ -15,9 +15,10 @@ A task is the main unit of planning and usually should have the following criter
 
 More information about task estimation can be found [here](http://blog.scrumstudy.com/how-do-scrum-teams-estimate-tasks-in-a-project/) and [here](https://resources.collab.net/agile-101/feature-estimation-of-user-stories).
 
-### [Estimation Techniques](../TaskEstimation/EstimationTechniques.md)
+### Required Reading:
+* ### [Estimation Techniques](../TaskEstimation/EstimationTechniques.md)
 
-### [Best Practices](BestPractices.md)
+* ### [Best Practices](BestPractices.md)
 
 ## Quick Links
   * [Home Page](../README.md)

--- a/TaskEstimation/TaskEstimation.md
+++ b/TaskEstimation/TaskEstimation.md
@@ -5,6 +5,14 @@
 It is the process of measuring the complexity (size) of stories in an Agile project.  
 The basic unit of measure is *Story Points* (SP). It is used to measure the size of the story, much the same like a kilogram is used to find out how heavy an object is.
 
+During task estimation meetings, the team looks at a list of tasks and estimates the effort required for each of them to be completed. It enables the team to have a shared perspective of the user stories and requirements in order to estimate an accurate value for the effort required. The information developed in such meetings will also be used to determine the velocity for the Sprint.
+
+A task is the main unit of planning and usually should have the following criteria:
+* Provide business value
+* Be estimable
+* Be small enough
+* Be testable
+
 ### [Estimation Techniques](../TaskEstimation/EstimationTechniques.md)
 
 ## Best Practices

--- a/TaskEstimation/TaskEstimation.md
+++ b/TaskEstimation/TaskEstimation.md
@@ -13,6 +13,8 @@ A task is the main unit of planning and usually should have the following criter
 * Be small enough
 * Be testable
 
+More information about task estimation can be found [here](http://blog.scrumstudy.com/how-do-scrum-teams-estimate-tasks-in-a-project/) and [here](https://resources.collab.net/agile-101/feature-estimation-of-user-stories).
+
 ### [Estimation Techniques](../TaskEstimation/EstimationTechniques.md)
 
 ## Best Practices

--- a/TaskEstimation/TaskEstimation.md
+++ b/TaskEstimation/TaskEstimation.md
@@ -17,29 +17,4 @@ More information about task estimation can be found [here](http://blog.scrumstud
 
 ### [Estimation Techniques](../TaskEstimation/EstimationTechniques.md)
 
-## Best Practices
-
-* **Engage the whole team**  
-  By giving everyone a chance to be involved in the estimation process you gain the benefits of having <ins>different insights</ins> and <ins>different perspectives</ins> on estimating a task. Essentially it generates a better consensus and commitment for the estimates being produced.
-
-* **Use multiple techniques**  
-  It is important to use multiple techniques or methods for estimating a task (e.g. planning poker, bottom-up, user story points, etc.) and look for similarities between multiple approaches to make sure the estimates are more accurate.
-
-* **Agree on the definition of "Done"**  
-  Make sure everyone agrees on a definition of done. It can mean:  
-  * Coded and tested
-  * Integrated and tested
-  * Integrated, tested and closed the JIRA task
-  * etc.
-
-* **Know when to stop**  
-  Estimating is not an exact science and it can be exhausting estimating an unpredictable task that can change because of evolving requirements. Make sure to get a <ins>broad consensus</ins> between team members. It is better to save time on estimation for potential periodic updates than wasting too much time now.
-
-* **Estimation is a continuous process**  
-  The initial estimate is not the final estimate. To avoid high levels of uncertainty, <ins>periodically review</ins> any uncertain estimates based on new information or requirements received.
-
-* **Aim to understand each other**  
-  Accept estimate values as long as there is a good rationale agreement. If there is any conflict, it must be handled within the team by understanding the reason for disagreement and adjust estimate values accordingly.
-
-* **Use non-linear scale**  
-  It is better to use a non-linear scale such as in the Fibonacci sequence, (e.g. 1,4,9,16). That is because it is quite hard to judge the difference in a linear scale between 3 and 4 compared to judging the difference between  4 and 9. To avoid number bias, clothes sizes can also be used (e.g. S,M,L,XL).
+### [Best Practices](BestPractices.md)

--- a/TaskEstimation/TaskEstimation.md
+++ b/TaskEstimation/TaskEstimation.md
@@ -18,3 +18,6 @@ More information about task estimation can be found [here](http://blog.scrumstud
 ### [Estimation Techniques](../TaskEstimation/EstimationTechniques.md)
 
 ### [Best Practices](BestPractices.md)
+
+## Quick Links
+  * [Home Page](../README.md)


### PR DESCRIPTION
Updated quick links in estimation techniques file
Added quick link in the home page of task estimation
The links for estimation techniques and best practices in the task estimation home page are now under the title required reading

This pull request must be merged after the branch "update-best-practices-te" is merged