### PR TITLE
Fix name spelling

### DIFF
--- a/ProjectPlan.md
+++ b/ProjectPlan.md
@@ -3,11 +3,11 @@
 ## Members
 * Tomi Ilori
 * Sean McElroy
-* Nicolai Bolan
+* Nicolai Boian
 * Ronan Macken
 
 ## Topics
-1. Task Estimation - Nicolai Bolan
+1. Task Estimation - Nicolai Boian
 2. Coding Standards - Sean McElroy
 3. Code Reviews - Ronan Macken
 4. Document Presentation, Bad Practices, Referencing, Introduction - Tomi Ilori

--- a/ProjectPlan.md
+++ b/ProjectPlan.md
@@ -48,4 +48,4 @@
 * Discuss style guide at the start to avoid having to largely remodel document.
 * Use one folder for images to prevent images files from not loading due to being in different directories.
 * Make more commits in a feature branch and then in pull request describe the changes made, more clearly rather than having multiple feature branches.
-* Make use of github "projects" tab , this would have allowed us plan the document better and see what tasks are in the process of being completed or have been completed.
+* Make use of GitHub "projects" tab , this would have allowed us plan the document better and see what tasks are in the process of being completed or have been completed.


### PR DESCRIPTION
Fixed spelling error in name
Changed an instance of "github" to "GitHub"